### PR TITLE
[ai] Add getActions()

### DIFF
--- a/src/main/java/com/leekwars/generator/FightConstants.java
+++ b/src/main/java/com/leekwars/generator/FightConstants.java
@@ -3,6 +3,8 @@ package com.leekwars.generator;
 import com.leekwars.generator.attack.Attack;
 import com.leekwars.generator.attack.effect.Effect;
 import com.leekwars.generator.fight.Fight;
+import com.leekwars.generator.fight.action.Action;
+import com.leekwars.generator.fight.action.DamageType;
 
 import leekscript.common.Type;
 import leekscript.runner.ILeekConstant;
@@ -318,7 +320,63 @@ public enum FightConstants implements ILeekConstant {
 	FIGHT_CONTEXT_BATTLE_ROYALE(Fight.CONTEXT_BATTLE_ROYALE, Type.INT),
 
 	SUMMON_LIMIT(Fight.SUMMON_LIMIT, Type.INT),
-	CRITICAL_FACTOR(Effect.CRITICAL_FACTOR, Type.REAL);
+	CRITICAL_FACTOR(Effect.CRITICAL_FACTOR, Type.REAL),
+
+	// Actions
+	ACTION_START_FIGHT(Action.START_FIGHT, Type.INT),
+	ACTION_USE_WEAPON(Action.USE_WEAPON, Type.INT),
+	ACTION_USE_CHIP(Action.USE_CHIP, Type.INT),
+	ACTION_SET_WEAPON(Action.SET_WEAPON, Type.INT),
+	ACTION_END_FIGHT(Action.END_FIGHT, Type.INT),
+	ACTION_PLAYER_DEAD(Action.PLAYER_DEAD, Type.INT),
+	ACTION_NEW_TURN(Action.NEW_TURN, Type.INT),
+	ACTION_LEEK_TURN(Action.LEEK_TURN, Type.INT),
+	ACTION_END_TURN(Action.END_TURN, Type.INT),
+	ACTION_SUMMON(Action.SUMMON, Type.INT),
+	ACTION_MOVE_TO(Action.MOVE_TO, Type.INT),
+	ACTION_KILL(Action.KILL, Type.INT),
+
+	// Buffs
+	ACTION_TP_LOST(Action.LOST_PT, Type.INT),
+	ACTION_LIFE_LOST(Action.LOST_LIFE, Type.INT),
+	ACTION_MP_LOST(Action.LOST_PM, Type.INT),
+	ACTION_HEAL(Action.HEAL, Type.INT),
+	ACTION_VITALITY(Action.VITALITY, Type.INT),
+	ACTION_RESURRECT(Action.RESURRECT, Type.INT),
+	ACTION_LOSE_STRENGTH(Action.LOSE_STRENGTH, Type.INT),
+	ACTION_NOVA_DAMAGE(Action.NOVA_DAMAGE, Type.INT),
+	ACTION_DAMAGE_RETURN(Action.DAMAGE_RETURN, Type.INT),
+	ACTION_LIFE_DAMAGE(Action.LIFE_DAMAGE, Type.INT),
+	ACTION_POISON_DAMAGE(Action.POISON_DAMAGE, Type.INT),
+	ACTION_AFTEREFFECT(Action.AFTEREFFECT, Type.INT),
+	ACTION_NOVA_VITALITY(Action.NOVA_VITALITY, Type.INT),
+
+	// "fun" actions
+	ACTION_SAY(Action.SAY, Type.INT),
+	ACTION_LAMA(Action.LAMA, Type.INT),
+	ACTION_SHOW_CELL(Action.SHOW_CELL, Type.INT),
+
+	// Effects
+	ACTION_ADD_WEAPON_EFFECT(Action.ADD_WEAPON_EFFECT, Type.INT),
+	ACTION_ADD_CHIP_EFFECT(Action.ADD_CHIP_EFFECT, Type.INT),
+	ACTION_REMOVE_EFFECT(Action.REMOVE_EFFECT, Type.INT),
+	ACTION_UPDATE_EFFECT(Action.UPDATE_EFFECT, Type.INT),
+	ACTION_ADD_STACKED_EFFECT(Action.ADD_STACKED_EFFECT, Type.INT),
+	ACTION_REDUCE_EFFECTS(Action.REDUCE_EFFECTS, Type.INT),
+	ACTION_REMOVE_POISONS(Action.REMOVE_POISONS, Type.INT),
+	ACTION_REMOVE_SHACKLES(Action.REMOVE_SHACKLES, Type.INT),
+
+	// Other
+	ACTION_ERROR(Action.ERROR, Type.INT),
+	ACTION_MAP(Action.MAP, Type.INT),
+	ACTION_AI_ERROR(Action.AI_ERROR, Type.INT),
+
+	ACTION_DAMAGE_TYPE_DIRECT(DamageType.DIRECT.value, Type.INT),
+	ACTION_DAMAGE_TYPE_NOVA(DamageType.NOVA.value, Type.INT),
+	ACTION_DAMAGE_TYPE_RETURN(DamageType.RETURN.value, Type.INT),
+    ACTION_DAMAGE_TYPE_LIFE(DamageType.LIFE.value, Type.INT),
+    ACTION_DAMAGE_TYPE_POISON(DamageType.POISON.value, Type.INT),
+    ACTION_DAMAGE_TYPE_AFTEREFFECT(DamageType.AFTEREFFECT.value, Type.INT);
 
 	private double value;
 	private Type type;

--- a/src/main/java/com/leekwars/generator/FightConstants.java
+++ b/src/main/java/com/leekwars/generator/FightConstants.java
@@ -104,6 +104,8 @@ public enum FightConstants implements ILeekConstant {
 	EFFECT_REPEL(Effect.TYPE_REPEL, Type.INT),
 	EFFECT_RAW_RELATIVE_SHIELD(Effect.TYPE_RAW_RELATIVE_SHIELD, Type.INT),
 	EFFECT_ALLY_KILLED_TO_AGILITY(Effect.TYPE_ALLY_KILLED_TO_AGILITY, Type.INT),
+	EFFECT_KILL_TO_TP(Effect.TYPE_KILL_TO_TP, Type.INT),
+	EFFECT_RAW_HEAL(Effect.TYPE_RAW_HEAL, Type.INT),
 
 	// Résultats attaque
 	USE_CRITICAL(2, Type.INT),
@@ -150,6 +152,8 @@ public enum FightConstants implements ILeekConstant {
 	WEAPON_SWORD(185, Type.INT),
 	WEAPON_HEAVY_SWORD(186, Type.INT),
 	WEAPON_DARK_KATANA(187, Type.INT),
+	WEAPON_ENHANCED_LIGHTNINGER(225, Type.INT),
+	WEAPON_UNSTABLE_DESTROYER(226, Type.INT),
 
 	// Messages
 	MESSAGE_HEAL(1, Type.INT),

--- a/src/main/java/com/leekwars/generator/FightFunctions.java
+++ b/src/main/java/com/leekwars/generator/FightFunctions.java
@@ -1144,6 +1144,12 @@ public enum FightFunctions implements ILeekFunction {
 			return null;
 		}
 	},
+	getActions(0) {
+		@Override
+		public Object run(AI ai, ILeekFunction function, Object... parameters) throws LeekRunException {
+			return ((EntityAI) ai).getActions();
+		}
+	},
 	getRegisters(0) {
 		@Override
 		public Object run(AI ai, ILeekFunction function, Object... parameters) throws LeekRunException {

--- a/src/main/java/com/leekwars/generator/attack/chips/Chips.java
+++ b/src/main/java/com/leekwars/generator/attack/chips/Chips.java
@@ -8,10 +8,16 @@ import com.leekwars.generator.items.Items;
 public class Chips {
 
 	private static Map<Integer, Chip> chips = new TreeMap<Integer, Chip>();
+	private static Map<Integer, Chip> template2chips = new TreeMap<Integer, Chip>();
 
 	public static void addChip(Chip chip) {
 		chips.put(chip.getId(), chip);
+		template2chips.put(chip.getTemplate(), chip);
 		Items.addChip(chip.getId());
+	}
+
+	public static Chip getChipFromTemplate(int template) {
+		return template2chips.get(template);
 	}
 
 	public static Chip getChip(int id) {

--- a/src/main/java/com/leekwars/generator/attack/effect/Effect.java
+++ b/src/main/java/com/leekwars/generator/attack/effect/Effect.java
@@ -71,6 +71,9 @@ public abstract class Effect {
 	public final static int TYPE_REPEL = 53;
 	public final static int TYPE_RAW_RELATIVE_SHIELD = 54;
 	public final static int TYPE_ALLY_KILLED_TO_AGILITY = 55;
+	public final static int TYPE_KILL_TO_TP = 56;
+	public final static int TYPE_RAW_HEAL = 57;
+	public final static int TYPE_CRITICAL_TO_HEAL = 58;
 
 	// Target filters constants
 	public final static int TARGET_ENEMIES = 1; // Enemies
@@ -146,6 +149,8 @@ public abstract class Effect {
 		EffectRepel.class, // 53
 		EffectRawRelativeShield.class, // 54
 		null, // 55
+		null, // 56
+		EffectRawHeal.class, // 57
 	};
 
 	// Effect characteristics

--- a/src/main/java/com/leekwars/generator/attack/effect/EffectDamage.java
+++ b/src/main/java/com/leekwars/generator/attack/effect/EffectDamage.java
@@ -44,7 +44,7 @@ public class EffectDamage extends Effect {
 		target.onNovaDamage(erosion);
 
 		// Life steal
-		if (!caster.isDead() && lifeSteal > 0) {
+		if (!caster.isDead() && lifeSteal > 0 && caster.getLife() < caster.getTotalLife()) {
 
 			if (caster.getLife() + lifeSteal > caster.getTotalLife()) {
 				lifeSteal = caster.getTotalLife() - caster.getLife();

--- a/src/main/java/com/leekwars/generator/attack/effect/EffectRawHeal.java
+++ b/src/main/java/com/leekwars/generator/attack/effect/EffectRawHeal.java
@@ -1,0 +1,19 @@
+package com.leekwars.generator.attack.effect;
+
+import com.leekwars.generator.fight.Fight;
+import com.leekwars.generator.fight.action.ActionHeal;
+
+public class EffectRawHeal extends Effect {
+
+	@Override
+	public void apply(Fight fight) {
+
+		value = (int) Math.round((value1 + jet * value2) * aoe * criticalPower * targetCount);
+
+		if (target.getLife() + value > target.getTotalLife()) {
+			value = target.getTotalLife() - target.getLife();
+		}
+		fight.log(new ActionHeal(target, value));
+		target.addLife(caster, value);
+	}
+}

--- a/src/main/java/com/leekwars/generator/attack/weapons/Weapons.java
+++ b/src/main/java/com/leekwars/generator/attack/weapons/Weapons.java
@@ -8,10 +8,16 @@ import com.leekwars.generator.items.Items;
 public class Weapons {
 
 	private static Map<Integer, Weapon> weapons = new TreeMap<Integer, Weapon>();
+	private static Map<Integer, Weapon> template2weapons = new TreeMap<Integer, Weapon>();
 
 	public static void addWeapon(Weapon weapon) {
 		weapons.put(weapon.getId(), weapon);
+		template2weapons.put(weapon.getTemplate(), weapon);
 		Items.addWeapon(weapon.getId());
+	}
+
+	public static Weapon getWeaponFromTemplate(int template) {
+		return template2weapons.get(template);
 	}
 
 	public static Weapon getWeapon(int id) {

--- a/src/main/java/com/leekwars/generator/fight/Fight.java
+++ b/src/main/java/com/leekwars/generator/fight/Fight.java
@@ -145,7 +145,7 @@ public class Fight {
 	private int context;
 	private int type;
 
-	JSONObject custom_map = null;
+	public JSONObject custom_map = null;
 	public StatisticsManager statistics;
 	private RegisterManager registerManager;
 	public long executionTime = 0;
@@ -565,6 +565,11 @@ public class Fight {
 				ally.onAllyKilled();
 			}
 		}
+
+		// Passive effect kill
+		if (killer != null) {
+			killer.onKill();
+		}
 	}
 
 	/*
@@ -643,6 +648,7 @@ public class Fight {
 		var cellEntity = target.getPlayer();
 		ActionUseWeapon log_use = new ActionUseWeapon(launcher, target, weapon, result);
 		actions.log(log_use);
+		if (critical) launcher.onCritical();
 		List<Entity> target_leeks = weapon.getAttack().applyOnCell(this, launcher, target, critical);
 		log_use.setEntities(target_leeks);
 		statistics.useWeapon(launcher, weapon, target, target_leeks, cellEntity);
@@ -690,6 +696,7 @@ public class Fight {
 		var cellEntity = target.getPlayer();
 		ActionUseChip log = new ActionUseChip(caster, target, template, result);
 		actions.log(log);
+		if (critical) caster.onCritical();
 		List<Entity> targets = template.getAttack().applyOnCell(this, caster, target, critical);
 		log.setEntities(targets);
 		statistics.useChip(caster, template, target, targets, cellEntity);
@@ -821,6 +828,7 @@ public class Fight {
 
 		ActionUseChip log = new ActionUseChip(caster, target, template, result);
 		actions.log(log);
+		if (critical) caster.onCritical();
 
 		// On invoque
 		Entity summon = createSummon(caster, (int) params.getValue1(), target, value, template.getLevel(), critical);
@@ -871,6 +879,7 @@ public class Fight {
 
 		ActionUseChip log = new ActionUseChip(caster, target, template, result);
 		actions.log(log);
+		if (critical) caster.onCritical();
 
 		// Resurrect
 		resurrect(caster, target_entity, target, critical);

--- a/src/main/java/com/leekwars/generator/fight/action/ActionEndTurn.java
+++ b/src/main/java/com/leekwars/generator/fight/action/ActionEndTurn.java
@@ -5,9 +5,9 @@ import com.leekwars.generator.fight.entity.Entity;
 
 public class ActionEndTurn implements Action {
 
-	private final int target;
-	private final int pt;
-	private final int pm;
+	public final int target;
+	public final int pt;
+	public final int pm;
 
 	public ActionEndTurn(Entity target) {
 

--- a/src/main/java/com/leekwars/generator/fight/action/ActionEntityTurn.java
+++ b/src/main/java/com/leekwars/generator/fight/action/ActionEntityTurn.java
@@ -5,7 +5,7 @@ import com.leekwars.generator.fight.entity.Entity;
 
 public class ActionEntityTurn implements Action {
 
-	private final int id;
+	public final int id;
 
 	public ActionEntityTurn(Entity leek) {
 		if (leek == null)

--- a/src/main/java/com/leekwars/generator/fight/action/ActionUseChip.java
+++ b/src/main/java/com/leekwars/generator/fight/action/ActionUseChip.java
@@ -9,11 +9,11 @@ import com.leekwars.generator.maps.Cell;
 
 public class ActionUseChip implements Action {
 
-	private final int caster;
-	private final int cell;
-	private final int chip;
-	private final int success;
-	private int[] leeks;
+	public final int caster;
+	public final int cell;
+	public final int chip;
+	public final int success;
+	public int[] leeks;
 
 	public ActionUseChip(Entity caster, Cell cell, Chip chip, int success) {
 		this.caster = caster.getFId();

--- a/src/main/java/com/leekwars/generator/fight/action/ActionUseWeapon.java
+++ b/src/main/java/com/leekwars/generator/fight/action/ActionUseWeapon.java
@@ -9,11 +9,11 @@ import com.leekwars.generator.maps.Cell;
 
 public class ActionUseWeapon implements Action {
 
-	private final int caster;
-	private final int cell;
-	private final int weapon;
-	private final int success;
-	private int[] leeks;
+	public final int caster;
+	public final int cell;
+	public final int weapon;
+	public final int success;
+	public int[] leeks;
 
 	public ActionUseWeapon(Entity caster, Cell cell, Weapon weapon, int success) {
 

--- a/src/main/java/com/leekwars/generator/fight/action/Actions.java
+++ b/src/main/java/com/leekwars/generator/fight/action/Actions.java
@@ -1,6 +1,7 @@
 package com.leekwars.generator.fight.action;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.alibaba.fastjson.JSONArray;
@@ -25,6 +26,21 @@ public class Actions {
 
 	public Actions() {
 		this.actions = new ArrayList<Action>();
+	}
+
+	public List<Action> getActionsAfter(int leekId) {
+		List<Action> result = new ArrayList<Action>();
+		int i = this.actions.size() - 1;
+		for (; i >= 0; i--) {
+			result.add(this.actions.get(i));
+			if (this.actions.get(i) instanceof ActionEntityTurn) {
+				if (((ActionEntityTurn) this.actions.get(i)).id == leekId) {
+					break;
+				}
+			}
+		}
+		Collections.reverse(result);
+		return result;
 	}
 
 	public int getEffectId() {

--- a/src/main/java/com/leekwars/generator/fight/action/Actions.java
+++ b/src/main/java/com/leekwars/generator/fight/action/Actions.java
@@ -32,12 +32,12 @@ public class Actions {
 		List<Action> result = new ArrayList<Action>();
 		int i = this.actions.size() - 1;
 		for (; i >= 0; i--) {
-			result.add(this.actions.get(i));
-			if (this.actions.get(i) instanceof ActionEntityTurn) {
-				if (((ActionEntityTurn) this.actions.get(i)).id == leekId) {
+			if (this.actions.get(i) instanceof ActionEndTurn) {
+				if (((ActionEndTurn) this.actions.get(i)).target == leekId) {
 					break;
 				}
 			}
+			result.add(this.actions.get(i));
 		}
 		Collections.reverse(result);
 		return result;

--- a/src/main/java/com/leekwars/generator/fight/entity/Entity.java
+++ b/src/main/java/com/leekwars/generator/fight/entity/Entity.java
@@ -484,6 +484,22 @@ public abstract class Entity {
 		}
 	}
 
+	public void onCritical() {
+		for (Weapon weapon : mWeapons) {
+			for (EffectParameters effect : weapon.getPassiveEffects()) {
+				activateOnCriticalPassiveEffect(effect, weapon.getAttack());
+			}
+		}
+	}
+
+	public void onKill() {
+		for (Weapon weapon : mWeapons) {
+			for (EffectParameters effect : weapon.getPassiveEffects()) {
+				activateOnKillPassiveEffect(effect, weapon.getAttack());
+			}
+		}
+	}
+
 	public void activateOnMovedPassiveEffect(EffectParameters effect, Attack attack) {
 		if (effect.getId() == Effect.TYPE_MOVED_TO_MP) {
 			double value = effect.getValue1();
@@ -526,6 +542,24 @@ public abstract class Entity {
 			double value = effect.getValue1();
 			boolean stackable = (effect.getModifiers() & Effect.MODIFIER_STACKABLE) != 0;
 			Effect.createEffect(this.fight, Effect.TYPE_RAW_BUFF_AGILITY, effect.getTurns(), 1, value, 0, false, this, this, attack, 0, stackable, 0, 0, 0, effect.getModifiers());
+		}
+	}
+
+	public void activateOnCriticalPassiveEffect(EffectParameters effect, Attack attack) {
+		if (effect.getId() == Effect.TYPE_CRITICAL_TO_HEAL) {
+			if (this.getLife() < this.getTotalLife()) {
+				double value1 = effect.getValue1();
+				double value2 = effect.getValue2();
+				double jet = fight.getRandom().getDouble();
+				Effect.createEffect(this.fight, Effect.TYPE_RAW_HEAL, 0, 1, value1, value2, false, this, this, attack, jet, false, 0, 1, 0, effect.getModifiers());
+			}
+		}
+	}
+
+	public void activateOnKillPassiveEffect(EffectParameters effect, Attack attack) {
+		if (effect.getId() == Effect.TYPE_KILL_TO_TP) {
+			double value = effect.getValue1();
+			Effect.createEffect(this.fight, Effect.TYPE_RAW_BUFF_TP, effect.getTurns(), 1, value, value, false, this, this, attack, 0, true, 0, 1, 0, effect.getModifiers());
 		}
 	}
 

--- a/src/main/java/com/leekwars/generator/fight/entity/EntityAI.java
+++ b/src/main/java/com/leekwars/generator/fight/entity/EntityAI.java
@@ -2714,7 +2714,7 @@ public class EntityAI extends AI {
 
 	public ArrayLeekValue getActions() throws LeekRunException {
 		ArrayLeekValue array = new ArrayLeekValue();
-		for (Action action : fight.getActions().getActionsAfter(fight.getOrder().getNextPlayer().getFId())) {
+		for (Action action : fight.getActions().getActionsAfter(getEntity())) {
 			JSONArray json = action.getJSON();
 			// Patch weapons and chips actions: convert templates to id
 			if (action instanceof ActionSetWeapon) {

--- a/src/main/java/com/leekwars/generator/fight/entity/EntityAI.java
+++ b/src/main/java/com/leekwars/generator/fight/entity/EntityAI.java
@@ -20,12 +20,15 @@ import com.leekwars.generator.attack.effect.Effect;
 import com.leekwars.generator.attack.weapons.Weapon;
 import com.leekwars.generator.attack.weapons.Weapons;
 import com.leekwars.generator.fight.Fight;
+import com.leekwars.generator.fight.action.Action;
 import com.leekwars.generator.fight.action.ActionAIError;
 import com.leekwars.generator.fight.action.ActionLama;
 import com.leekwars.generator.fight.action.ActionLoseTP;
 import com.leekwars.generator.fight.action.ActionSay;
 import com.leekwars.generator.fight.action.ActionSetWeapon;
 import com.leekwars.generator.fight.action.ActionShowCell;
+import com.leekwars.generator.fight.action.ActionUseChip;
+import com.leekwars.generator.fight.action.ActionUseWeapon;
 import com.leekwars.generator.fight.bulbs.BulbTemplate;
 import com.leekwars.generator.fight.bulbs.Bulbs;
 import com.leekwars.generator.items.Items;
@@ -45,6 +48,8 @@ import leekscript.runner.LeekRunException;
 import leekscript.runner.values.ArrayLeekValue;
 import leekscript.runner.values.FunctionLeekValue;
 import leekscript.common.Error;
+
+import com.alibaba.fastjson.JSONArray;
 
 public class EntityAI extends AI {
 
@@ -2705,6 +2710,41 @@ public class EntityAI extends AI {
 				return l.getAI().getId();
 		}
 		return null;
+	}
+
+	public ArrayLeekValue getActions() throws LeekRunException {
+		ArrayLeekValue array = new ArrayLeekValue();
+		for (Action action : fight.getActions().getActionsAfter(fight.getOrder().getNextPlayer().getFId())) {
+			JSONArray json = action.getJSON();
+			// Patch weapons and chips actions: convert templates to id
+			if (action instanceof ActionSetWeapon) {
+				json.set(2, Weapons.getWeaponFromTemplate(((ActionSetWeapon) action).weapon).getId());
+			}
+			if (action instanceof ActionUseWeapon) {
+				json.set(3, Weapons.getWeaponFromTemplate(((ActionUseWeapon) action).weapon).getId());
+			}
+			if (action instanceof ActionUseChip) {
+				json.set(3, Chips.getChipFromTemplate(((ActionUseChip) action).chip).getId());
+			}
+
+			// Convert JSON to ArrayLeek:
+			ArrayLeekValue actionLeek = new ArrayLeekValue();
+			for (int i=0; i<json.size(); i++) {
+				if (json.get(i) instanceof int[]) {
+					ArrayLeekValue arrayLeek = new ArrayLeekValue();
+					JSONArray arrayJson = json.getJSONArray(i);
+					for (int j=0; j<arrayJson.size(); j++) {
+						arrayLeek.push(this, arrayJson.getIntValue(j));
+					}
+					actionLeek.push(this, arrayLeek);
+				} else {
+					actionLeek.push(this, json.get(i));
+				}
+			}
+
+			array.push(this, actionLeek);
+		}
+		return array;
 	}
 
 	public ArrayLeekValue getRegisters() throws LeekRunException {

--- a/test/ai/debugActions.leek
+++ b/test/ai/debugActions.leek
@@ -1,0 +1,42 @@
+say("hello world")
+
+var debugAction = [
+    ACTION_START_FIGHT: function(action) {
+        return "Start fight"
+    },
+    ACTION_USE_WEAPON: function(action) {
+        return getName(action[1])+": useWeaponOnCell("+getWeaponName(action[3])+", "+action[2]+")"
+    },
+    ACTION_USE_CHIP: function(action) {
+        return getName(action[1])+": useChipOnCell("+getChipName(action[3])+", "+action[2]+")"
+    },
+    ACTION_SET_WEAPON: function(action) {
+        return getName(action[1])+": setWeapon("+getWeaponName(action[2])+")"
+    },
+    ACTION_MOVE_TO: function(action) {
+        return getName(action[1])+": moveTowardCell("+action[2]+")"
+    },
+    ACTION_SAY: function(action) {
+        return getName(action[1])+": say("+action[2]+")"
+    },
+    ACTION_TP_LOST: function(action) {
+        return getName(action[1])+" perd "+action[2]+" TP"
+    },
+    ACTION_MP_LOST: function(action) {
+        return getName(action[1])+" perd "+action[2]+" MP"
+    },
+    ACTION_LEEK_TURN: function(action) {
+        return "Début du tour de "+getName(action[1])
+    },
+    ACTION_END_TURN: function(action) {
+        return "Fin du tour de "+getName(action[1])
+    }
+]
+
+for (var action in getActions()) {
+    if (debugAction[action[0]] === null) {
+        debug("Unknown action: "+action[0])
+    } else {
+        debug(debugAction[action[0]](action))
+    }
+}

--- a/test/scenario/scenario2.json
+++ b/test/scenario/scenario2.json
@@ -1,0 +1,100 @@
+{	"farmers": [
+		{	"id": 1,
+			"name": "Pilow",
+			"country": "fr"
+		},
+		{	"id": 2,
+			"name": "Dawyde",
+			"country": "fr"
+		}
+	],
+	"teams": [
+		{	"id": 1,
+			"name": "DoT"
+		},
+		{	"id": 2,
+			"name": "Polytech"
+		}
+	],
+	"entities": [
+		[
+			{	"id": 12,
+				"ai": "test/ai/debugActions.leek",
+				"name": "Patrick",
+				"type": 1,
+				"farmer": 1,
+				"team": 1,
+				"level": 301,
+				"life": 5000,
+				"strength": 500,
+				"tp": 20,
+				"mp": 6,
+				"cell": 123,
+				"weapons": [37, 47],
+				"chips": [29]
+			},
+			{	"id": 57,
+				"ai": "test/ai/basic.leek",
+				"name": "Yolo",
+				"type": 1,
+				"farmer": 1,
+				"team": 1,
+				"level": 200,
+				"life": 3000,
+				"strength": 200,
+				"tp": 10,
+				"mp": 8,
+				"cell": 566,
+				"weapons": [47]
+			}
+		],
+		[
+			{	"id": 59,
+				"ai": "test/ai/basic.leek",
+				"name": "Boss",
+				"type": 1,
+				"farmer": 2,
+				"team": 2,
+				"level": 1000,
+				"life": 10000,
+				"strength": 2000,
+				"tp": 50,
+				"mp": 6,
+				"cell": 301,
+				"weapons": [37],
+				"chips": []
+			},
+			{	"id": 89,
+				"ai": "test/ai/basic.leek",
+				"name": "Bob",
+				"type": 1,
+				"farmer": 2,
+				"team": 2,
+				"level": 100,
+				"life": 3000,
+				"strength": 200,
+				"agility": 150,
+				"tp": 10,
+				"mp": 8,
+				"resistance": 67,
+				"science": 300,
+				"magic": 200,
+				"frequency": 100,
+				"cell": 566,
+				"weapons": [37],
+				"chips": []
+			}
+		]
+	],
+	"map": {
+		"width": 17,
+		"height": 17,
+		"type": 3,
+		"obstacles": [
+			123, 54, 212, 561, 231, 678, 122, 545, 753, 321, 565, 89
+		]
+	},
+	"random_seed": 1234567,
+	"max_turns": 3,
+	"max_operations_per_entity": 20000000
+}


### PR DESCRIPTION
Ajout d'une fonction `getActions()` qui permet de récupérer l'historique des actions jusqu'au dernier tour de l'entitée courante.

La valeur retournée est quasiement identique au tableau d'action retournée par l'api, sauf que les template des armes et chips sont remplacés par leur id, pour faciliter le décodage en leekscript.