### PR TITLE
feat(functions): déclare la pureté des fonctions de combat pour @pure

### DIFF
--- a/src/main/java/com/leekwars/generator/FightFunctions.java
+++ b/src/main/java/com/leekwars/generator/FightFunctions.java
@@ -2,6 +2,7 @@ package com.leekwars.generator;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import leekscript.common.Type;
 import leekscript.runner.CallableVersion;
@@ -10,6 +11,30 @@ import leekscript.runner.LeekFunctions;
 public class FightFunctions {
 
 	private static HashMap<String, LeekFunctions> functions = new HashMap<>();
+
+	// Fight functions that produce an observable side effect on the fight (they move
+	// or act, write to persistent registers, emit network messages, or draw on the
+	// map / log). Calling one of these from a @pure LeekScript function makes that
+	// function impure and is reported (Error.ANNOTATION_NOT_PURE). Every other fight
+	// function only reads or computes from the fight state and is treated as pure by
+	// default — so a new read-only getter needs no change here, while a new action
+	// must be added below.
+	private static final Set<String> IMPURE_FUNCTIONS = Set.of(
+		// Movement
+		"moveToward", "moveTowardCell", "moveTowardCells", "moveTowardEntities",
+		"moveTowardLeeks", "moveTowardLine",
+		"moveAwayFrom", "moveAwayFromCell", "moveAwayFromCells", "moveAwayFromEntities",
+		"moveAwayFromLeeks", "moveAwayFromLine",
+		// Combat / loadout actions
+		"useChip", "useChipOnCell", "useWeapon", "useWeaponOnCell",
+		"summon", "resurrect", "setWeapon", "setLoadout",
+		// Communication
+		"say", "lama", "sendAll", "sendTo",
+		// Map drawing / debugging
+		"mark", "markText", "clearMarks", "show", "pause",
+		// Persistent registers
+		"setRegister", "deleteRegister"
+	);
 
 	static {
 
@@ -572,6 +597,9 @@ public class FightFunctions {
 
 	private static LeekFunctions method(String name, String clazz, int operations, boolean isStatic, CallableVersion[] versions) {
 		var function = new LeekFunctions(clazz, name, operations, isStatic, versions);
+		if (IMPURE_FUNCTIONS.contains(name)) {
+			function.setImpure();
+		}
 		functions.put(name, function);
 		return function;
 	}

--- a/src/test/java/test/TestPurity.java
+++ b/src/test/java/test/TestPurity.java
@@ -1,0 +1,68 @@
+package test;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.leekwars.generator.FightFunctions;
+
+import leekscript.common.Error;
+import leekscript.compiler.AnalyzeError;
+import leekscript.compiler.LeekScript;
+import leekscript.compiler.Options;
+import leekscript.runner.AI;
+import leekscript.runner.LeekConstants;
+import leekscript.runner.LeekFunctions;
+
+/**
+ * Vérifie que la pureté déclarée sur les fonctions du générateur (FightFunctions)
+ * est bien prise en compte par l'annotation {@code @pure} de LeekScript : appeler
+ * une fonction de combat à effet de bord (déplacement, action, I/O, registre…)
+ * depuis une fonction {@code @pure} doit être signalé, tandis qu'un getter en
+ * lecture seule reste autorisé.
+ */
+public class TestPurity {
+
+	@BeforeClass
+	public static void setUp() {
+		new File("ai/").mkdir();
+		LeekFunctions.setExtraFunctions(FightFunctions.getFunctions(), "com.leekwars.generator.classes.*");
+		LeekConstants.setExtraConstants("com.leekwars.generator.FightConstants");
+	}
+
+	private static boolean notPure(String code) throws Exception {
+		AI ai = LeekScript.compileSnippet(code, "com.leekwars.generator.fight.entity.EntityAI", new Options());
+		List<AnalyzeError> errors = ai.getFile().getErrors();
+		return errors.stream().anyMatch(e -> e.error == Error.ANNOTATION_NOT_PURE);
+	}
+
+	@Test
+	public void impureFightFunctionsFlagged() throws Exception {
+		// Déplacement
+		Assert.assertTrue(notPure("@pure function f() { moveToward(getNearestEnemy()); return 0 } return f()"));
+		// Action de combat
+		Assert.assertTrue(notPure("@pure function f() { useChip(1, getNearestEnemy()); return 0 } return f()"));
+		// I/O
+		Assert.assertTrue(notPure("@pure function f() { say(\"hi\"); return 0 } return f()"));
+		// Registre persistant
+		Assert.assertTrue(notPure("@pure function f() { setRegister(\"a\", \"b\"); return 0 } return f()"));
+	}
+
+	@Test
+	public void pureFightFunctionsAllowed() throws Exception {
+		// Les getters ne lisent que l'état du combat : aucun effet de bord
+		Assert.assertFalse(notPure("@pure function f() { return getLife() } return f()"));
+		Assert.assertFalse(notPure("@pure function f() { return getCellDistance(1, 2) } return f()"));
+		Assert.assertFalse(notPure("@pure function f() { return getNearestEnemy() } return f()"));
+	}
+
+	@Test
+	public void impurityReachedThroughHelperFlagged() throws Exception {
+		// La pureté est transitive : une fonction non annotée qui appelle une
+		// fonction de combat impure rend impure la fonction @pure qui l'appelle.
+		Assert.assertTrue(notPure("function helper() { say(\"x\"); return 0 } @pure function f() { return helper() } return f()"));
+	}
+}


### PR DESCRIPTION
Les fonctions de combat à effet de bord (déplacements, actions d'arme et de puce, communication, dessin sur la carte, registres persistants) sont marquées setImpure() via une liste IMPURE_FUNCTIONS appliquée à l'enregistrement ; toutes les autres (getters en lecture seule) restent pures par défaut. Ainsi, ajouter un getter ne demande rien, mais une nouvelle action doit être listée.

Appeler une fonction de combat impure depuis une fonction @pure est désormais signalé (ANNOTATION_NOT_PURE), y compris de façon transitive via une fonction intermédiaire non annotée.